### PR TITLE
Fix errant Claim test

### DIFF
--- a/tests/Psecio/Jwt/ClaimTest.php
+++ b/tests/Psecio/Jwt/ClaimTest.php
@@ -31,7 +31,7 @@ class ClaimTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testGetValue()
 	{
-		$type = $this->claim->getType();
-		$this->assertEquals('test123', $this->value);
+		$value = $this->claim->getValue();
+		$this->assertEquals($this->value, $value);
 	}
 }


### PR DESCRIPTION
The test in the ClaimTest test case was supposed to be testing
that the Claim object's value is set correctly. However, it was
testing that the ClaimTest `$value` property was equal to a literal
string value.
