### PR TITLE
Addresses #7 & #8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: php
-before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+
 php:
-  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+
+before_script:
+  - wget -nc http://getcomposer.org/composer.phar
+  - php composer.phar install
+
 script: phpunit

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $jwt
 
 $result = $jwt->encode();
 echo 'ENCODED: '.print_r($result)."\n\n";
-echo 'DECODED: '.var_export($jwt->decode($result), true);
+echo 'DECODED: '.var_export($jwt->decode($result), $key, true, true);
 
 ?>
 ```
@@ -87,7 +87,7 @@ echo "DECRYPTED: ".var_export($jwt->decrypt($result, 'AES-256-CBC', '12345678123
 
 ### Custom Claim values
 
-You can also add your own custom claim values to the JWT payload using the `custom` method. The first paramater is the value and the second is the claim "type" (key):
+You can also add your own custom claim values to the JWT payload using the `custom` method. The first parameter is the value and the second is the claim "type" (key):
 
 ```php
 <?php
@@ -102,7 +102,7 @@ $jwt->custom('foobar', 'custom-claim');
 
 $result = $jwt->encode();
 echo 'ENCODED: '.print_r($result)."\n\n";
-echo 'DECODED: '.var_export($jwt->decode($result), true);
+echo 'DECODED: '.var_export($jwt->decode($result), $key, true, true);
 ?>
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php":">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.4"
+        "phpunit/phpunit": "4.3.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Psecio/Jwt/Jwt.php
+++ b/src/Psecio/Jwt/Jwt.php
@@ -308,7 +308,9 @@ class Jwt
 			4 - (strlen($data) % 4),
 			'='
 		);
-		return base64_decode(strtr($decoded, '-_', '+/'));
+
+		// use the strict parameter to fail if the JWT contains characters it shouldn't have
+		return base64_decode(strtr($decoded, '-_', '+/'), true);
 	}
 
 	/**


### PR DESCRIPTION
This pull request looks a little scary, but fixes the key issue that the `decrypt` function never validated the signature nor any of the claims.

In addition, the requirement of initialising the `Jwt` class with a `Header` object is quite strange when you consider decoding or decryption. I believe the key and algorithm should be derived from the actual token that is received instead of the code. Because of this, I have made the constructor optionally set the `Header`. In the instance of a `decrypt`, the `Header` object will be created on the fly using the information provided in the token.

To maximise code reuse, I have split the two requirements for verifying a signature, and validating claims into two parameters on the `decode` method. These both default to `true`.
